### PR TITLE
Fix GameMetadata executable paths

### DIFF
--- a/europa1400_manager/game_metadata.py
+++ b/europa1400_manager/game_metadata.py
@@ -48,15 +48,15 @@ class GameMetadata:
         match self.edition:
             case GameEdition.STANDARD:
                 return (
-                    Path(GILDE_TL_EXE_PATH)
+                    Path(GILDE_EXE_PATH)
                     if self.language == GameLanguage.GERMAN
-                    else Path(EUROPA1400_TL_EXE_PATH)
+                    else Path(EUROPA1400_EXE_PATH)
                 )
             case GameEdition.GOLD:
                 return (
-                    Path(GILDE_GOLD_TL_EXE_PATH)
+                    Path(GILDE_GOLD_EXE_PATH)
                     if self.language == GameLanguage.GERMAN
-                    else Path(EUROPA1400_GOLD_TL_EXE_PATH)
+                    else Path(EUROPA1400_GOLD_EXE_PATH)
                 )
             case _:
                 raise ValueError(f"Unsupported edition: {self.edition}")
@@ -69,15 +69,15 @@ class GameMetadata:
         match self.edition:
             case GameEdition.STANDARD:
                 return (
-                    Path(GILDE_EXE_PATH)
+                    Path(GILDE_TL_EXE_PATH)
                     if self.language == GameLanguage.GERMAN
-                    else Path(EUROPA1400_EXE_PATH)
+                    else Path(EUROPA1400_TL_EXE_PATH)
                 )
             case GameEdition.GOLD:
                 return (
-                    Path(GILDE_GOLD_EXE_PATH)
+                    Path(GILDE_GOLD_TL_EXE_PATH)
                     if self.language == GameLanguage.GERMAN
-                    else Path(EUROPA1400_GOLD_EXE_PATH)
+                    else Path(EUROPA1400_GOLD_TL_EXE_PATH)
                 )
             case _:
                 raise ValueError(f"Unsupported edition: {self.edition}")

--- a/tests/test_game_metadata.py
+++ b/tests/test_game_metadata.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pytest
+
+from europa1400_manager.game_metadata import GameMetadata
+from europa1400_manager.const import (
+    GameEdition,
+    GameLanguage,
+    EUROPA1400_EXE_PATH,
+    EUROPA1400_GOLD_EXE_PATH,
+    EUROPA1400_TL_EXE_PATH,
+    EUROPA1400_GOLD_TL_EXE_PATH,
+    GILDE_EXE_PATH,
+    GILDE_GOLD_EXE_PATH,
+    GILDE_TL_EXE_PATH,
+    GILDE_GOLD_TL_EXE_PATH,
+)
+
+
+@pytest.mark.parametrize(
+    "edition,language,exp_exe,exp_tl",
+    [
+        (GameEdition.STANDARD, GameLanguage.ENGLISH, EUROPA1400_EXE_PATH, EUROPA1400_TL_EXE_PATH),
+        (GameEdition.STANDARD, GameLanguage.GERMAN, GILDE_EXE_PATH, GILDE_TL_EXE_PATH),
+        (GameEdition.GOLD, GameLanguage.ENGLISH, EUROPA1400_GOLD_EXE_PATH, EUROPA1400_GOLD_TL_EXE_PATH),
+        (GameEdition.GOLD, GameLanguage.GERMAN, GILDE_GOLD_EXE_PATH, GILDE_GOLD_TL_EXE_PATH),
+    ],
+)
+def test_executable_paths(edition, language, exp_exe, exp_tl):
+    meta = GameMetadata(edition=edition, language=language)
+    assert meta.executable_path == Path(exp_exe)
+    assert meta.tl_executable_path == Path(exp_tl)

--- a/tests/test_game_metadata.py
+++ b/tests/test_game_metadata.py
@@ -1,7 +1,4 @@
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 
 from europa1400_manager.game_metadata import GameMetadata


### PR DESCRIPTION
## Summary
- correct `GameMetadata` executable resolution
- add regression tests for the executable path properties

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8a0bfa90833187286579c93aa479